### PR TITLE
Ignore use statements that import nothing

### DIFF
--- a/lib/Perl/Critic/Policy/Moose/RequireCleanNamespace.pm
+++ b/lib/Perl/Critic/Policy/Moose/RequireCleanNamespace.pm
@@ -44,6 +44,12 @@ sub violates {
     return if not $includes;
 
     for my $include ( @{$includes} ) {
+        # skip if nothing imported
+        if ( $include->type eq 'use' ) {
+            my $lists = $include->find('PPI::Structure::List');
+            next if $lists && !grep { $_->children > 0 } @{$lists};
+        }
+
         $modules{ $include->type }->{ $include->module } = 1;
     }
 

--- a/t/Moose/RequireCleanNamespace.run
+++ b/t/Moose/RequireCleanNamespace.run
@@ -130,3 +130,9 @@ has foo => (
     is  => 'rw',
     isa => 'Str',
 );
+
+## name Moose without imports
+## failures 0
+## cut
+
+use Moose ();


### PR DESCRIPTION
Update RequireCleanNamespace to not require a cleaner if nothing was
imported. Allows "use Moose ();", as recommended by Moose::Exporter.

Better logic than previous pull request, thanks to karenetheridge's review.
