### PR TITLE
Ignore use statements that import nothing

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+- Make Perl::Critic::Policy::Moose::RequireCleanNamespace ignore use
+  statements of the form "use Moose ()". Since this doesn't import anything,
+  there's nothing to clean. PR #3 by Noel Maddy.
+
+
 1.02     2015-04-21
 
 - Make all policies accept an "equivalent_modules" config parameter. If you

--- a/lib/Perl/Critic/Policy/Moose/RequireCleanNamespace.pm
+++ b/lib/Perl/Critic/Policy/Moose/RequireCleanNamespace.pm
@@ -44,6 +44,12 @@ sub violates {
     return if not $includes;
 
     for my $include ( @{$includes} ) {
+        # skip if nothing imported
+        if ( $include->type eq 'use' ) {
+            my $lists = $include->find('PPI::Structure::List');
+            next if $lists and not grep { $_->children > 0 } @{$lists};
+        }
+
         $modules{ $include->type }->{ $include->module } = 1;
     }
 
@@ -102,6 +108,9 @@ can set the C<cleaners> option.
 
     [Moose::RequireCleanNamespace]
     cleaners = My::Cleaner
+
+If you use C<use> a module with an empty import list, then this module knows
+that nothing needs to be cleaned, and will ignore that particular import.
 
 =head1 SEE ALSO
 

--- a/t/Moose/RequireCleanNamespace.run
+++ b/t/Moose/RequireCleanNamespace.run
@@ -130,3 +130,9 @@ has foo => (
     is  => 'rw',
     isa => 'Str',
 );
+
+## name Moose without imports
+## failures 0
+## cut
+
+use Moose ();


### PR DESCRIPTION
Update RequireCleanNamespace to not require a cleaner if nothing was
imported. Allows "use Moose ();", as recommended by Moose::Exporter.
